### PR TITLE
 #304: Fixed AuditLog to provide RUN_ID even if no LogSpan is provided

### DIFF
--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Bugfixes
+
+* #304: Fixed AuditLog to provide RUN_ID even if no LogSpan is provided
+
 ## Refactorings
 
 * #309: Removed GitHub workflow `ci-cd.yml`

--- a/exasol/analytics/audit/audit.py
+++ b/exasol/analytics/audit/audit.py
@@ -102,17 +102,17 @@ class AuditTable(Table):
 
     def _insert(self, query: AuditQuery) -> Query:
         def log_span_fields(log_span: LogSpan | None):
-            return (
-                base_column_values(
-                    {
-                        BaseAuditColumns.RUN_ID: str(self._run_id),
-                        BaseAuditColumns.LOG_SPAN_NAME: log_span.name,
-                        BaseAuditColumns.LOG_SPAN_ID: str(log_span.id),
-                    },
-                    log_span.parent,
-                )
-                if log_span
-                else {}
+            run_id = {
+                BaseAuditColumns.RUN_ID: str(self._run_id)
+            }
+            if not log_span:
+                return base_column_values(run_id)
+            return base_column_values(
+                run_id | {
+                    BaseAuditColumns.LOG_SPAN_NAME: log_span.name,
+                    BaseAuditColumns.LOG_SPAN_ID: str(log_span.id),
+                },
+                log_span.parent,
             )
 
         constants = query.audit_fields | log_span_fields(query.log_span)

--- a/tests/unit_tests/audit_log/test_with_python_runner.py
+++ b/tests/unit_tests/audit_log/test_with_python_runner.py
@@ -246,11 +246,13 @@ def test_audit(
             INSERT INTO {audit_table.name.fully_qualified} (
               "LOG_TIMESTAMP",
               "SESSION_ID",
-              "EVENT_ATTRIBUTES"
+              "EVENT_ATTRIBUTES",
+              "RUN_ID"
             ) SELECT
               SYSTIMESTAMP(),
               CURRENT_SESSION,
-              '{{{{"c": 456}}}}'
+              '{{{{"c": 456}}}}',
+              'RUN_ID_2'
             """
         ),
         # sub query of final audit log query


### PR DESCRIPTION
Closes #304 